### PR TITLE
Make entry for tailwind.config

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -38,7 +38,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         [null, {\
           "packageLocation": "./",\
           "packageDependencies": [\
-            ["eslint", "npm:8.46.0"],\
             ["prettier", "npm:2.8.7"],\
             ["typescript", "patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"]\
           ],\
@@ -9180,6 +9179,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["eslint-plugin-jsx-a11y", "virtual:ca413596134045d5108a820540cb6b2f52efee384eee2aabfd289dd001db814aeb4e29483fa0b724f21ba6710c99e81f8c499112ee659bf2571f90b67065385f#npm:6.7.1"],\
             ["eslint-plugin-react", "virtual:ca413596134045d5108a820540cb6b2f52efee384eee2aabfd289dd001db814aeb4e29483fa0b724f21ba6710c99e81f8c499112ee659bf2571f90b67065385f#npm:7.33.1"],\
             ["eslint-plugin-react-hooks", "virtual:ca413596134045d5108a820540cb6b2f52efee384eee2aabfd289dd001db814aeb4e29483fa0b724f21ba6710c99e81f8c499112ee659bf2571f90b67065385f#npm:5.0.0-canary-7118f5dd7-20230705"],\
+            ["next", "virtual:ca413596134045d5108a820540cb6b2f52efee384eee2aabfd289dd001db814aeb4e29483fa0b724f21ba6710c99e81f8c499112ee659bf2571f90b67065385f#npm:13.4.13"],\
             ["typescript", "patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"]\
           ],\
           "packagePeers": [\
@@ -12282,7 +12282,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageLocation": "./",\
           "packageDependencies": [\
             ["mono", "workspace:."],\
-            ["eslint", "npm:8.46.0"],\
             ["prettier", "npm:2.8.7"],\
             ["typescript", "patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"]\
           ],\
@@ -12401,6 +12400,48 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["next", "npm:13.4.13"]\
           ],\
           "linkType": "SOFT"\
+        }],\
+        ["virtual:ca413596134045d5108a820540cb6b2f52efee384eee2aabfd289dd001db814aeb4e29483fa0b724f21ba6710c99e81f8c499112ee659bf2571f90b67065385f#npm:13.4.13", {\
+          "packageLocation": "./.yarn/__virtual__/next-virtual-e3a0b3fd11/0/cache/next-npm-13.4.13-faba52c50a-49c161ffaf.zip/node_modules/next/",\
+          "packageDependencies": [\
+            ["next", "virtual:ca413596134045d5108a820540cb6b2f52efee384eee2aabfd289dd001db814aeb4e29483fa0b724f21ba6710c99e81f8c499112ee659bf2571f90b67065385f#npm:13.4.13"],\
+            ["@next/env", "npm:13.4.13"],\
+            ["@next/swc-darwin-arm64", "npm:13.4.13"],\
+            ["@next/swc-darwin-x64", "npm:13.4.13"],\
+            ["@next/swc-linux-arm64-gnu", "npm:13.4.13"],\
+            ["@next/swc-linux-arm64-musl", "npm:13.4.13"],\
+            ["@next/swc-linux-x64-gnu", "npm:13.4.13"],\
+            ["@next/swc-linux-x64-musl", "npm:13.4.13"],\
+            ["@next/swc-win32-arm64-msvc", "npm:13.4.13"],\
+            ["@next/swc-win32-ia32-msvc", "npm:13.4.13"],\
+            ["@next/swc-win32-x64-msvc", "npm:13.4.13"],\
+            ["@opentelemetry/api", null],\
+            ["@swc/helpers", "npm:0.5.1"],\
+            ["@types/opentelemetry__api", null],\
+            ["@types/react", null],\
+            ["@types/react-dom", null],\
+            ["@types/sass", null],\
+            ["busboy", "npm:1.6.0"],\
+            ["caniuse-lite", "npm:1.0.30001519"],\
+            ["postcss", "npm:8.4.14"],\
+            ["react", null],\
+            ["react-dom", null],\
+            ["sass", null],\
+            ["styled-jsx", "virtual:e3a0b3fd114eb5f137b6930d7af5dca6f9a6d920ba071e7ea81737d7a004467364521ab870aee548668dc44a4f9717d542d431a6ef80af153aec43cf226a5a69#npm:5.1.1"],\
+            ["watchpack", "npm:2.4.0"],\
+            ["zod", "npm:3.21.4"]\
+          ],\
+          "packagePeers": [\
+            "@opentelemetry/api",\
+            "@types/opentelemetry__api",\
+            "@types/react-dom",\
+            "@types/react",\
+            "@types/sass",\
+            "react-dom",\
+            "react",\
+            "sass"\
+          ],\
+          "linkType": "HARD"\
         }],\
         ["virtual:fda629d4c8640a425fb0c3a726684627537ca6dc48d316e524c00fc5e22b65d7d548fe71931f7f5f7c369f4660de1af8d9834d06551d978c4966b63eaa9e329a#npm:13.4.13", {\
           "packageLocation": "./.yarn/__virtual__/next-virtual-1bb816b9cf/0/cache/next-npm-13.4.13-faba52c50a-49c161ffaf.zip/node_modules/next/",\
@@ -14996,6 +15037,28 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["babel-plugin-macros", null],\
             ["client-only", "npm:0.0.1"],\
             ["react", "npm:18.2.0"]\
+          ],\
+          "packagePeers": [\
+            "@babel/core",\
+            "@types/babel-plugin-macros",\
+            "@types/babel__core",\
+            "@types/react",\
+            "babel-plugin-macros",\
+            "react"\
+          ],\
+          "linkType": "HARD"\
+        }],\
+        ["virtual:e3a0b3fd114eb5f137b6930d7af5dca6f9a6d920ba071e7ea81737d7a004467364521ab870aee548668dc44a4f9717d542d431a6ef80af153aec43cf226a5a69#npm:5.1.1", {\
+          "packageLocation": "./.yarn/__virtual__/styled-jsx-virtual-16a7cbc5b0/0/cache/styled-jsx-npm-5.1.1-2557a209ba-523a33b386.zip/node_modules/styled-jsx/",\
+          "packageDependencies": [\
+            ["styled-jsx", "virtual:e3a0b3fd114eb5f137b6930d7af5dca6f9a6d920ba071e7ea81737d7a004467364521ab870aee548668dc44a4f9717d542d431a6ef80af153aec43cf226a5a69#npm:5.1.1"],\
+            ["@babel/core", null],\
+            ["@types/babel-plugin-macros", null],\
+            ["@types/babel__core", null],\
+            ["@types/react", null],\
+            ["babel-plugin-macros", null],\
+            ["client-only", "npm:0.0.1"],\
+            ["react", null]\
           ],\
           "packagePeers": [\
             "@babel/core",\

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     ]
   },
   "devDependencies": {
-    "eslint": "^8.46.0",
     "prettier": "2.8.7",
     "typescript": "^5.1.6"
   }

--- a/packages/app/src/pages/_app.tsx
+++ b/packages/app/src/pages/_app.tsx
@@ -1,6 +1,5 @@
 import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
-import '@mono/ui/styles.css';
 
 export default function App({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;

--- a/packages/app/src/pages/index.tsx
+++ b/packages/app/src/pages/index.tsx
@@ -6,6 +6,8 @@ export default function Home() {
       <div>
         <MolecularComponent color='primary' description='this is molecular' />
       </div>
+      <p className='text-red-400'>test tailwind.config override</p>
+      <p className='headline-1-semibold text-red-400'>test tailwind.config override</p>
       <div>
         <AtomicComponent color='secondary' />
       </div>

--- a/packages/app/src/styles/globals.css
+++ b/packages/app/src/styles/globals.css
@@ -1,3 +1,5 @@
+@import '@mono/ui/styles.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/packages/app/tailwind.config.ts
+++ b/packages/app/tailwind.config.ts
@@ -1,20 +1,15 @@
-import type { Config } from 'tailwindcss'
+import type { Config } from 'tailwindcss';
 
 const config: Config = {
+  presets: [require('@mono/ui/tailwind.config')],
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    extend: {
-      backgroundImage: {
-        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
-        'gradient-conic':
-          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
-      },
-    },
+    extend: {},
   },
   plugins: [],
-}
-export default config
+};
+export default config;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "scripts": {
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "build": "vite build && yarn build:css",
-    "build:css": "tailwindcss -m -i ./src/tailwind-entry.css -o ./dist/styles.css",
+    "clean": "rm -rf dist",
+    "build": "yarn clean && vite build && yarn build:css",
+    "build:watch": "yarn clean && yarn build:css && vite build --watch",
+    "build:css": "tailwindcss -m -i ./src/tailwind-entry.css -o ./dist/styles.css && cp tailwind.config.js ./dist",
     "storybook": "concurrently \"yarn storybook:css\" \"storybook dev -p 6006\"",
     "storybook:css": "tailwindcss -w -i ./src/tailwind-entry.css -o ./src/index.css",
     "build-storybook": "concurrently \"yarn build-storybook:css\" \"storybook build\"",
@@ -29,6 +31,10 @@
     "./styles.css": {
       "require": "./dist/styles.css",
       "default": "./dist/styles.css"
+    },
+    "./tailwind.config": {
+      "require": "./dist/tailwind.config.js",
+      "default": "./dist/tailwind.config.js"
     }
   },
   "devDependencies": {

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -1,8 +1,18 @@
+import plugin from 'tailwindcss/plugin';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    plugin(function ({ addComponents }) {
+      addComponents({
+        '.headline-1-semibold': {
+          '@apply text-xl font-semibold': {},
+        },
+      });
+    }),
+  ],
 };

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -8,6 +8,7 @@ import { resolve } from 'node:path';
 export default defineConfig({
   plugins: [react(), tsconfigPaths(), dts()],
   build: {
+    emptyOutDir: false,
     sourcemap: true,
     lib: {
       entry: resolve('src', 'index.ts'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6773,7 +6773,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:8.46.0, eslint@npm:^8.45.0, eslint@npm:^8.46.0":
+"eslint@npm:8.46.0, eslint@npm:^8.45.0":
   version: 8.46.0
   resolution: "eslint@npm:8.46.0"
   dependencies:
@@ -9270,7 +9270,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "mono@workspace:."
   dependencies:
-    eslint: ^8.46.0
     prettier: 2.8.7
     typescript: ^5.1.6
   languageName: unknown
@@ -9366,7 +9365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:13.4.13":
+"next@npm:*, next@npm:13.4.13":
   version: 13.4.13
   resolution: "next@npm:13.4.13"
   dependencies:


### PR DESCRIPTION
### Make entry for tailwind.config
1. `ui` package exports `tailwind.config`
    
2. By importing `@mono/ui/tailwind.config`, a package use it as a preset.
    ```ts
    //  packages/app/tailwind.config.ts

    const config: Config = {
      presets: [require('@mono/ui/tailwind.config')],
      ...
    ```
