### PR TITLE
Add script for workspaces from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
       "packages/*"
     ]
   },
+  "scripts": {
+    "app": "yarn workspace @mono/app",
+    "ui": "yarn workspace @mono/ui"
+  },
   "devDependencies": {
     "prettier": "2.8.7",
     "typescript": "^5.1.6"


### PR DESCRIPTION
### Add script for workspaces from root
1. changing directory is not needed to run script for each workspace.
2. For example, these two execute same scripts as a result.

    ```bash
    # root
    cd packages/ui
    yarn build

    # root
    yarn ui build
    ```

