### PR TITLE
Fix not create sourceMap for entry on ui build

### DIFF
--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -6,7 +6,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "references": [{ "path": "../ui/tsconfig.json" }], // to avoid circular dependencies
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,8 +29,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
 
-    "incremental": true,
-
-    "composite": true
+    "incremental": true
   }
 }


### PR DESCRIPTION
### Fix not create sourceMap for entry on ui build
### 1. reverts [5657841](https://github.com/2wheeh/mono/pull/9/commits/565784129b2b9b3d39c80b19f4a6da030ad31eb2)
it seems that `vite-plugin-dts` doesn't create sourceMap for entry on `composite: true`